### PR TITLE
u-boot: Switch console to usb

### DIFF
--- a/layers/meta-resin-beaglebone/conf/machine/beaglebone-pocket.conf
+++ b/layers/meta-resin-beaglebone/conf/machine/beaglebone-pocket.conf
@@ -7,3 +7,4 @@ MACHINEOVERRIDES = "beaglebone:${MACHINE}"
 include conf/machine/beaglebone.conf
 
 KERNEL_DEVICETREE_beaglebone-pocket = "am335x-pocketbeagle.dtb "
+SERIAL_CONSOLE_beaglebone-pocket = "115200 ttyGS0"

--- a/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0001-u-boot-Disable-logging-on-UART0.patch
+++ b/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0001-u-boot-Disable-logging-on-UART0.patch
@@ -1,0 +1,38 @@
+From 25d206cefd71295e3cb70ac2672814f12501219f Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Fri, 7 Dec 2018 16:17:08 +0200
+Subject: [PATCH] u-boot: Disable logging on UART0
+
+Switched console to ttyGS0 to free-up UART0
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ include/configs/am335x_evm.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/configs/am335x_evm.h b/include/configs/am335x_evm.h
+index 33d6b1e..4d6fc00 100644
+--- a/include/configs/am335x_evm.h
++++ b/include/configs/am335x_evm.h
+@@ -96,7 +96,7 @@
+ 	"bootdir=/boot\0" \
+ 	"bootfile=zImage\0" \
+ 	"fdtfile=undefined\0" \
+-	"console=ttyO0,115200n8\0" \
++	"console=ttyGS0,115200n8\0" \
+ 	"partitions=" \
+ 		"uuid_disk=${uuid_gpt_disk};" \
+ 		"name=rootfs,start=2MiB,size=-,uuid=${uuid_gpt_rootfs}\0" \
+@@ -154,7 +154,7 @@
+ 		"if test $board_name = A335_ICE; then "\
+ 			"setenv console ttyO3,115200n8;" \
+ 		"else " \
+-			"setenv console ttyO0,115200n8;" \
++			"setenv console ttyGS0,115200n8;" \
+ 		"fi;\0" \
+ 	NANDARGS \
+ 	NETARGS \
+-- 
+2.7.4
+

--- a/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/layers/meta-resin-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -11,6 +11,11 @@ SRC_URI_append = " \
     file://0001-Add-support-for-BeagleBoard.org-PocketBeagle.patch \
     file://uEnv.txt_internal \
     "
+
+SRC_URI_append_beaglebone-pocket = " \
+    file://0001-u-boot-Disable-logging-on-UART0.patch \
+    "
+
 do_deploy_append () {
     install ${WORKDIR}/uEnv.txt_internal ${DEPLOYDIR}
 }


### PR DESCRIPTION
Switched console from ttyO0 to ttyGS0 over
USB to free up one uart which needs to
be used with other devices

Console will be available on the host as ttyACM0 after the gadget serial module is loaded on device side. Kernel logs will be visible in dmesg.