### PR TITLE
am335x-boneblack-wireless.dts: Use version from linux 4.9 branch

### DIFF
--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard-4.14/0001-Use-bbbw-dts-from-4.9.patch
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard-4.14/0001-Use-bbbw-dts-from-4.9.patch
@@ -1,0 +1,257 @@
+From 56a259b38e7732a859f0c58f5f87e28fc10e1f8d Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Thu, 31 Jan 2019 13:55:23 +0100
+Subject: [PATCH] Use kernel 4.9 BBBW dts version
+
+am335x-boneblack-wireless.dts: Use linux 4.9.34-ti-r43 version
+
+Use am335x-boneblack-wireless.dts added by commit
+8f591b5944e00c56682c9cc4f0397e1c30329c8b on linux-ti
+branch 4.9 by Robert Nelson.
+
+Versions from branch 4.14.53-ti-r62 and onwards added
+in the commit fbb5850bd3c13a7a804c2f47dbd9eeb05e4e4b4a
+breaks bluetooth on BBBW.
+
+---
+ arch/arm/boot/dts/am335x-boneblack-wireless.dts | 192 +++++++++++++++---------
+ 1 file changed, 119 insertions(+), 73 deletions(-)
+
+diff --git a/arch/arm/boot/dts/am335x-boneblack-wireless.dts b/arch/arm/boot/dts/am335x-boneblack-wireless.dts
+index b0610e2..9b39648 100644
+--- a/arch/arm/boot/dts/am335x-boneblack-wireless.dts
++++ b/arch/arm/boot/dts/am335x-boneblack-wireless.dts
+@@ -9,111 +9,157 @@
+ 
+ #include "am33xx.dtsi"
+ #include "am335x-bone-common.dtsi"
+-#include "am335x-boneblack-common.dtsi"
+-#include <dt-bindings/interrupt-controller/irq.h>
++#include <dt-bindings/display/tda998x.h>
++#include "am335x-boneblack-wl1835.dtsi"
+ /* #include "am335x-bone-jtag.dtsi" */
+ 
+ / {
+ 	model = "TI AM335x BeagleBone Black Wireless";
+-	compatible = "ti,am335x-bone-black-wireless", "ti,am335x-bone-black", "ti,am335x-bone", "ti,am33xx";
+-
+-	wlan_en_reg: fixedregulator@2 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "wlan-en-regulator";
+-		regulator-min-microvolt = <1800000>;
+-		regulator-max-microvolt = <1800000>;
+-		startup-delay-us= <70000>;
+-
+-		/* WL_EN */
+-		gpio = <&gpio3 9 0>;
+-		enable-active-high;
+-	};
++	compatible = "ti,am335x-bone-black", "ti,am335x-bone", "ti,am33xx";
++};
++
++&ldo3_reg {
++	regulator-min-microvolt = <1800000>;
++	regulator-max-microvolt = <1800000>;
++	regulator-always-on;
++};
++
++&mmc1 {
++	vmmc-supply = <&vmmcsd_fixed>;
++};
++
++&mmc2 {
++	vmmc-supply = <&vmmcsd_fixed>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_pins>;
++	bus-width = <8>;
++	status = "okay";
+ };
+ 
+-&sgx {
++&mac {
++	status = "disabled";
++};
++
++&mmc3 {
+ 	status = "okay";
+ };
+ 
+ &am33xx_pinmux {
+-	bt_pins: pinmux_bt_pins {
++	nxp_hdmi_bonelt_pins: nxp_hdmi_bonelt_pins {
+ 		pinctrl-single,pins = <
+-			AM33XX_IOPAD(0x928, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* gmii1_txd0.gpio0_28 - BT_EN */
++			AM33XX_IOPAD(0x9b0, PIN_OUTPUT_PULLDOWN | MUX_MODE3)	/* xdma_event_intr0 */
++			AM33XX_IOPAD(0x8a0, PIN_OUTPUT | MUX_MODE0)		/* lcd_data0.lcd_data0 */
++			AM33XX_IOPAD(0x8a4, PIN_OUTPUT | MUX_MODE0)		/* lcd_data1.lcd_data1 */
++			AM33XX_IOPAD(0x8a8, PIN_OUTPUT | MUX_MODE0)		/* lcd_data2.lcd_data2 */
++			AM33XX_IOPAD(0x8ac, PIN_OUTPUT | MUX_MODE0)		/* lcd_data3.lcd_data3 */
++			AM33XX_IOPAD(0x8b0, PIN_OUTPUT | MUX_MODE0)		/* lcd_data4.lcd_data4 */
++			AM33XX_IOPAD(0x8b4, PIN_OUTPUT | MUX_MODE0)		/* lcd_data5.lcd_data5 */
++			AM33XX_IOPAD(0x8b8, PIN_OUTPUT | MUX_MODE0)		/* lcd_data6.lcd_data6 */
++			AM33XX_IOPAD(0x8bc, PIN_OUTPUT | MUX_MODE0)		/* lcd_data7.lcd_data7 */
++			AM33XX_IOPAD(0x8c0, PIN_OUTPUT | MUX_MODE0)		/* lcd_data8.lcd_data8 */
++			AM33XX_IOPAD(0x8c4, PIN_OUTPUT | MUX_MODE0)		/* lcd_data9.lcd_data9 */
++			AM33XX_IOPAD(0x8c8, PIN_OUTPUT | MUX_MODE0)		/* lcd_data10.lcd_data10 */
++			AM33XX_IOPAD(0x8cc, PIN_OUTPUT | MUX_MODE0)		/* lcd_data11.lcd_data11 */
++			AM33XX_IOPAD(0x8d0, PIN_OUTPUT | MUX_MODE0)		/* lcd_data12.lcd_data12 */
++			AM33XX_IOPAD(0x8d4, PIN_OUTPUT | MUX_MODE0)		/* lcd_data13.lcd_data13 */
++			AM33XX_IOPAD(0x8d8, PIN_OUTPUT | MUX_MODE0)		/* lcd_data14.lcd_data14 */
++			AM33XX_IOPAD(0x8dc, PIN_OUTPUT | MUX_MODE0)		/* lcd_data15.lcd_data15 */
++			AM33XX_IOPAD(0x8e0, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* lcd_vsync.lcd_vsync */
++			AM33XX_IOPAD(0x8e4, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* lcd_hsync.lcd_hsync */
++			AM33XX_IOPAD(0x8e8, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* lcd_pclk.lcd_pclk */
++			AM33XX_IOPAD(0x8ec, PIN_OUTPUT_PULLDOWN | MUX_MODE0)	/* lcd_ac_bias_en.lcd_ac_bias_en */
+ 		>;
+ 	};
+-
+-	mmc3_pins: pinmux_mmc3_pins {
++	nxp_hdmi_bonelt_off_pins: nxp_hdmi_bonelt_off_pins {
+ 		pinctrl-single,pins = <
+-			AM33XX_IOPAD(0x93c, PIN_INPUT_PULLUP | MUX_MODE6 ) /* (L15) gmii1_rxd1.mmc2_clk */
+-			AM33XX_IOPAD(0x914, PIN_INPUT_PULLUP | MUX_MODE6 ) /* (J16) gmii1_txen.mmc2_cmd */
+-			AM33XX_IOPAD(0x918, PIN_INPUT_PULLUP | MUX_MODE5 ) /* (J17) gmii1_rxdv.mmc2_dat0 */
+-			AM33XX_IOPAD(0x91c, PIN_INPUT_PULLUP | MUX_MODE5 ) /* (J18) gmii1_txd3.mmc2_dat1 */
+-			AM33XX_IOPAD(0x920, PIN_INPUT_PULLUP | MUX_MODE5 ) /* (K15) gmii1_txd2.mmc2_dat2 */
+-			AM33XX_IOPAD(0x908, PIN_INPUT_PULLUP | MUX_MODE5 ) /* (H16) gmii1_col.mmc2_dat3 */
++			AM33XX_IOPAD(0x9b0, PIN_OUTPUT_PULLDOWN | MUX_MODE3)	/* xdma_event_intr0 */
+ 		>;
+ 	};
+ 
+-	uart3_pins: pinmux_uart3_pins {
++	mcasp0_pins: mcasp0_pins {
+ 		pinctrl-single,pins = <
+-			AM33XX_IOPAD(0x934, PIN_INPUT_PULLUP | MUX_MODE1)	/* gmii1_rxd3.uart3_rxd */
+-			AM33XX_IOPAD(0x938, PIN_OUTPUT_PULLDOWN | MUX_MODE1)	/* gmii1_rxd2.uart3_txd */
+-			AM33XX_IOPAD(0x948, PIN_INPUT | MUX_MODE3)		/* mdio_data.uart3_ctsn */
+-			AM33XX_IOPAD(0x94c, PIN_OUTPUT_PULLDOWN | MUX_MODE3)	/* mdio_clk.uart3_rtsn */
++			AM33XX_IOPAD(0x9ac, PIN_INPUT_PULLUP | MUX_MODE0) /* mcasp0_ahcklx.mcasp0_ahclkx */
++			AM33XX_IOPAD(0x99c, PIN_OUTPUT_PULLDOWN | MUX_MODE2) /* mcasp0_ahclkr.mcasp0_axr2*/
++			AM33XX_IOPAD(0x994, PIN_OUTPUT_PULLUP | MUX_MODE0) /* mcasp0_fsx.mcasp0_fsx */
++			AM33XX_IOPAD(0x990, PIN_OUTPUT_PULLDOWN | MUX_MODE0) /* mcasp0_aclkx.mcasp0_aclkx */
++			AM33XX_IOPAD(0x86c, PIN_OUTPUT_PULLDOWN | MUX_MODE7) /* gpmc_a11.GPIO1_27 */
+ 		>;
+ 	};
++};
+ 
+-	wl18xx_pins: pinmux_wl18xx_pins {
+-		pinctrl-single,pins = <
+-			AM33XX_IOPAD(0x92c, PIN_OUTPUT_PULLDOWN | MUX_MODE7)	/* gmii1_txclk.gpio3_9 WL_EN */
+-			AM33XX_IOPAD(0x944, PIN_INPUT_PULLDOWN | MUX_MODE7)	/* rmii1_refclk.gpio0_29 WL_IRQ */
+-			AM33XX_IOPAD(0x930, PIN_OUTPUT_PULLUP | MUX_MODE7)	/* gmii1_rxclk.gpio3_10 LS_BUF_EN */
+-		>;
++&lcdc {
++	status = "okay";
++	port {
++		lcdc_0: endpoint@0 {
++			remote-endpoint = <&hdmi_0>;
++		};
+ 	};
+ };
+ 
+-&mac {
+-	status = "disabled";
+-};
++&i2c0 {
++	tda19988: tda19988 {
++		compatible = "nxp,tda998x";
++		reg = <0x70>;
+ 
+-&mmc3 {
+-	dmas = <&edma_xbar 12 0 1
+-		&edma_xbar 13 0 2>;
+-	dma-names = "tx", "rx";
+-	status = "okay";
+-	vmmc-supply = <&wlan_en_reg>;
+-	bus-width = <4>;
+-	non-removable;
+-	cap-power-off-card;
+-	ti,needs-special-hs-handling;
+-	keep-power-in-suspend;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&mmc3_pins &wl18xx_pins>;
+-
+-	#address-cells = <1>;
+-	#size-cells = <0>;
+-	wlcore: wlcore@2 {
+-		compatible = "ti,wl1835";
+-		reg = <2>;
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <29 IRQ_TYPE_EDGE_RISING>;
++		pinctrl-names = "default", "off";
++		pinctrl-0 = <&nxp_hdmi_bonelt_pins>;
++		pinctrl-1 = <&nxp_hdmi_bonelt_off_pins>;
++
++		#sound-dai-cells = <0>;
++		audio-ports = <	TDA998x_I2S	0x03>;
++
++		ports {
++			port@0 {
++				hdmi_0: endpoint@0 {
++					remote-endpoint = <&lcdc_0>;
++				};
++			};
++		};
+ 	};
+ };
+ 
+-&uart3 {
++&mcasp0	{
++	#sound-dai-cells = <0>;
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&uart3_pins &bt_pins>;
++	pinctrl-0 = <&mcasp0_pins>;
+ 	status = "okay";
++	op-mode = <0>;	/* MCASP_IIS_MODE */
++	tdm-slots = <2>;
++	serial-dir = <	/* 0: INACTIVE, 1: TX, 2: RX */
++			0 0 1 0
++		>;
++	tx-num-evt = <32>;
++	rx-num-evt = <32>;
++};
+ 
+-	bluetooth {
+-		compatible = "ti,wl1835-st";
+-		enable-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
++/ {
++	clk_mcasp0_fixed: clk_mcasp0_fixed {
++		#clock-cells = <0>;
++		compatible = "fixed-clock";
++		clock-frequency = <24576000>;
+ 	};
+-};
+ 
+-&gpio3 {
+-	ls_buf_en {
+-		gpio-hog;
+-		gpios = <10 GPIO_ACTIVE_HIGH>;
+-		output-high;
+-		line-name = "LS_BUF_EN";
++	clk_mcasp0: clk_mcasp0 {
++		#clock-cells = <0>;
++		compatible = "gpio-gate-clock";
++		clocks = <&clk_mcasp0_fixed>;
++		enable-gpios = <&gpio1 27 0>; /* BeagleBone Black Clk enable on GPIO1_27 */
++	};
++
++	sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "TI BeagleBone Black";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,bitclock-master = <&dailink0_master>;
++		simple-audio-card,frame-master = <&dailink0_master>;
++
++		dailink0_master: simple-audio-card,cpu {
++			sound-dai = <&mcasp0>;
++			clocks = <&clk_mcasp0>;
++		};
++
++		simple-audio-card,codec {
++			sound-dai = <&tda19988>;
++		};
+ 	};
+ };
+-- 
+2.7.4
+

--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
@@ -7,3 +7,7 @@ RESIN_CONFIGS[no_modules_compression]=" \
 
 KERNEL_DEVICETREE_beaglebone += " am335x-boneblack-uboot.dtb \
 "
+
+SRC_URI_append_beaglebone = " \
+	file://0001-Use-bbbw-dts-from-4.9.patch \
+"


### PR DESCRIPTION
Switched back to 4.9.34-ti-r43 version of BBBW dts to fix
bluetooth timeout issue.

Newer versions of this dts from kernel branches 4.14 onwards
share the same issue - bluetooth timeout. This applies to
to dts versions from Official Debian images as well. However
official Debian images use overlays with which the issue is
not present.

Changelog-entry: Fix BT timeout on Beaglebone Black Wireless
Signed-off-by: Alexandru Costache <alexandru@balena.io>