### PR TITLE
linux-beagleboard: Disable reboot on kernel panic

### DIFF
--- a/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
+++ b/layers/meta-resin-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
@@ -15,3 +15,6 @@ SRC_URI_append_beaglebone = " \
 SRC_URI_append_beaglebone-green-wifi = " \
         file://0001-Use-kernel-4.9-BBGW-dts-version.patch \
 "
+
+RESIN_CONFIGS_append = " panic_no_reboot"
+RESIN_CONFIGS[panic_no_reboot] = "CONFIG_PANIC_TIMEOUT=0"


### PR DESCRIPTION
Current kernel on the beaglebone exhibits the following issue:
https://github.com/balena-os/balena-beaglebone/issues/177
As a workaround for this issue we disable the reboot on kernel
panic config so that the board can provision as expected.

Changelog-entry: Disable reboot on kernel panic as workaround for https://github.com/balena-os/balena-beaglebone/issues/177
Signed-off-by: Florin Sarbu <florin@balena.io>