### PR TITLE
Change poky submodule to use our github hosted mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = http://git.yoctoproject.org/git/meta-ti
 [submodule "layers/poky"]
 	path = layers/poky
-	url = https://git.yoctoproject.org/git/poky
+	url = https://github.com/balena-os/poky
 [submodule "balena-yocto-scripts"]
 	path = balena-yocto-scripts
 	url = https://github.com/balena-os/balena-yocto-scripts.git


### PR DESCRIPTION
We do this change because we noticed frequent timeouts
in different parts of our build infrastructure when pulling
the poky repository from https://git.yoctoproject.org/git/poky

Changelog-entry: Change the poky submodule to our github mirror
Signed-off-by: Florin Sarbu <florin@balena.io>