### PR TITLE
u-boot_2018.11.bbappend: Add support for OS_KERNEL_CMDLINE

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot/0005-env_default.h-Add-support-for-OS_KERNEL_CMDLINE.patch
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot/0005-env_default.h-Add-support-for-OS_KERNEL_CMDLINE.patch
@@ -1,0 +1,32 @@
+From da3b0246e3899e664f3b5a0be3c668ccf09f0692 Mon Sep 17 00:00:00 2001
+From: Florin Sarbu <florin@balena.io>
+Date: Fri, 3 May 2019 15:24:41 +0200
+Subject: [PATCH] env_default.h: Add support for OS_KERNEL_CMDLINE
+
+OS_KERNEL_CMDLINE is passed from meta-balena and contains cmdline arguments
+for production images (supressing writing the boot log to console, no terminal
+cursor blink etc).
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Florin Sarbu <florin@balena.io>
+---
+ include/env_default.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/env_default.h b/include/env_default.h
+index b18244f..d13388e 100644
+--- a/include/env_default.h
++++ b/include/env_default.h
+@@ -24,6 +24,9 @@ static char default_environment[] = {
+ const uchar default_environment[] = {
+ #endif
+     RESIN_ENV
++
++"cmdline=" __stringify(OS_KERNEL_CMDLINE) "\0" \
++
+ #ifndef CONFIG_USE_DEFAULT_ENV_FILE
+ #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
+ 	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
+-- 
+2.7.4
+

--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot_2018.11.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot_2018.11.bbappend
@@ -17,6 +17,7 @@ SRC_URI += " \
 	file://0004-Integrate-with-Balena-environment-configuration.patch \
 	file://0001-beaglebone-black-Use-Balena-vars-for-mmc-boot.patch \
 	file://0001-Load-uboot-device-tree-overlays.patch \
+	file://0005-env_default.h-Add-support-for-OS_KERNEL_CMDLINE.patch \
 "
 
 SRC_URI_append_beaglebone-pocket = " \
@@ -27,4 +28,9 @@ do_deploy_append() {
     install ${B}/MLO ${DEPLOYDIR}
     install ${B}/u-boot.img ${DEPLOYDIR}
     install ${WORKDIR}/uEnv.txt_internal ${DEPLOYDIR}
+}
+
+do_generate_resin_uboot_configuration_append() {
+    fl = open(os.path.join(d.getVar('S'), 'include', 'config_resin.h'), 'a')
+    fl.write("#define %s %s\n" % ('OS_KERNEL_CMDLINE', d.getVar('OS_KERNEL_CMDLINE')))
 }


### PR DESCRIPTION
The OS_KERNEL_CMDLINE variable is provided by meta-balena with
the purpose of supplying kernel cmdline arguments suitable for
production images (like for supressing boot messages from being
displayed to the console, removing cursor blink etc).

Changelog-entry: Add support for OS_KERNEL_CMDLINE
Signed-off-by: Florin Sarbu <florin@balena.io>