### PR TITLE
bb-org-overlays.bb: Added BB-UART4-RTSCTS-00A0.dts overlay

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/bb-org-overlays.bb
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/bb-org-overlays.bb
@@ -15,6 +15,7 @@ SRC_URI = " \
     file://BB-CAN0-00A0.dts \
     file://BB-I2C2N-00A0.dts \
     file://SDS-CAPE-00A0.dts \
+    file://BB-UART4-RTSCTS-00A0.dts \
     "
 
 S = "${WORKDIR}/git"
@@ -28,6 +29,7 @@ do_compile_prepend () {
     cp ${WORKDIR}/BB-CAN0-00A0.dts ${S}/src/arm/
     cp ${WORKDIR}/BB-I2C2N-00A0.dts ${S}/src/arm/
     cp ${WORKDIR}/SDS-CAPE-00A0.dts ${S}/src/arm/
+    cp ${WORKDIR}/BB-UART4-RTSCTS-00A0.dts ${S}/src/arm/
 }
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/bb-org-overlays/BB-UART4-RTSCTS-00A0.dts
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/bb-org-overlays/BB-UART4-RTSCTS-00A0.dts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018
+ * Yantrr Electronic Systems Pvt. Ltd. - http://www.yantrr.com/
+ *
+ * BeagleBone cape RS485 / RS422 using UART4-RTSCTS connector pins P8.33 P8.35
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or 
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+*/
+
+/dts-v1/;
+/plugin/;
+
+/{
+	compatible = "ti,beaglebone", "ti,beaglebone-black";
+
+	part-number = "BB-UART4-RTSCTS";
+	version = "00A0";
+
+	exclusive-use =
+		"P8.33",    // uart4_rtsn     conflict with HDMI pin
+		"P8.35";    // uart4_ctsn     conflict with HDMI pin
+
+	/*
+	 * Free up the pins used by the cape from the pinmux helpers.
+	 */
+	fragment@0 {
+		target = <&ocp>;
+		__overlay__ {
+			P8_33_pinmux { status = "disabled"; };	/* P8_33: mode 6 (uart4_rtsn) */
+			P8_35_pinmux { status = "disabled"; };	/* P8_35: mode 6 (uart4_ctsn) */
+		};
+	};
+
+	fragment@1 {
+		/* Sets pinmux for flow control pins. */
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			u4_rtscts_pins: pinmux_u4_rtscts_pins {
+				pinctrl-single,pins = <
+					0x0d4 0x0e	/* P8_33: mode 6 (uart4_rtsn) */
+					0x0d0 0x36	/* P8_35: mode 6 (uart4_ctsn) */
+				>;
+			};
+		};
+	};
+
+	fragment@2 {
+		/* Enable pinmux-helper driver for setting mux configuration. */
+		target = <&ocp>; /* On-Chip Peripherals */
+		__overlay__ {
+			uart4-rtscts-pinmux {
+				compatible = "bone-pinmux-helper"; /* Use the pinmux helper */
+				status="okay";
+				/* Define custom names for indexes in pinctrl array: */
+				pinctrl-names = "default";
+				/* Set the elements of the pinctrl array to the pinmux overlays
+				defined above: */
+				pinctrl-0 = <&u4_rtscts_pins>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
This overlay enables RTS/CTS flow control for UART4

Changelog-entry: bb-org-overlays.bb: Added BB-UART4-RTSCTS-00A0.dts overlay
Signed-off-by: Sharvin Shah sharvinshah51@gmail.com