### PR TITLE
linux-beagleboard: Power cycle SD card at boot on Beagleboard-XM

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard-4.14/0001-card-power-cycle.patch
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard-4.14/0001-card-power-cycle.patch
@@ -1,0 +1,34 @@
+From b78296008bd5cb492636d3f0e57ec7b3cd8f5d88 Mon Sep 17 00:00:00 2001
+From: Sebastian Panceac <sebastian@balena.io>
+Date: Tue, 18 Jun 2019 15:12:07 +0200
+Subject: [PATCH] Power cycle SD card at boot
+
+We need to power cycle the SD card at the initialization sequence
+to put it in a reset state. Otherwise, we will encounter this error
+that prevents boot:
+
+[    3.042205] mmc0: card never left busy state
+[    3.050262] mmc0: error -110 whilst initialising SD card
+
+Upstream-Status: Pending
+Signed-off-by: Sebastian Panceac <sebastian@balena.io>
+---
+ drivers/mmc/host/omap_hsmmc.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/mmc/host/omap_hsmmc.c b/drivers/mmc/host/omap_hsmmc.c
+index f2a1137be8bc..4b68986492e8 100644
+--- a/drivers/mmc/host/omap_hsmmc.c
++++ b/drivers/mmc/host/omap_hsmmc.c
+@@ -1607,6 +1607,8 @@ static void omap_hsmmc_set_ios(struct mmc_host *mmc, struct mmc_ios *ios)
+ 			omap_hsmmc_set_power(host, 0);
+ 			break;
+ 		case MMC_POWER_UP:
++			omap_hsmmc_set_power(host, 0);
++			msleep(10);
+ 			omap_hsmmc_set_power(host, 1);
+ 			break;
+ 		case MMC_POWER_ON:
+-- 
+2.17.1
+

--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
@@ -18,6 +18,7 @@ SRC_URI_append_beaglebone-green-wifi = " \
 
 SRC_URI_append_beagleboard-xm = " \
 	file://0001-set-gpios-vaux3.patch \
+	file://0001-card-power-cycle.patch \
 "
 
 RESIN_CONFIGS_append = " panic_no_reboot"


### PR DESCRIPTION
We need to power cycle the SD card at the initialization sequence
to put it in a reset state. Otherwise, we will encounter this
error that prevents boot:

[    3.042205] mmc0: card never left busy state
[    3.050262] mmc0: error -110 whilst initialising SD card

Signed-off-by: Sebastian Panceac <sebastian@balena.io>