### PR TITLE
bbgw: various fixes

### DIFF
--- a/beaglebone-green-wifi.coffee
+++ b/beaglebone-green-wifi.coffee
@@ -1,11 +1,11 @@
 deviceTypesCommon = require '@resin.io/device-types/common'
 { networkOptions, commonImg, instructions } = deviceTypesCommon
 
-BBB_FLASH = 'Power up the <%= TYPE_NAME %> while holding down the small button near the SD slot.
-You need to keep it pressed until the blue LEDs start flashing wildly.'
+BBGW_FLASH = 'Power up the <%= TYPE_NAME %>.'
+BBGW_REMOVE_POWER = 'Wait 5 seconds after the blue leds stopped flashing wildly, then remove power from the board. On some boards the leds will shut down completely.'
 
 postProvisioningInstructions = [
-	instructions.BOARD_SHUTDOWN
+	BBGW_REMOVE_POWER
 	instructions.REMOVE_INSTALL_MEDIA
 	instructions.BOARD_REPOWER
 ]
@@ -24,7 +24,7 @@ module.exports =
 		instructions.ETCHER_SD
 		instructions.EJECT_SD
 		instructions.FLASHER_WARNING
-		BBB_FLASH
+		BBGW_FLASH
 	].concat(postProvisioningInstructions)
 
 	gettingStartedLink:

--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard-4.14/0002-rtc-omap-Prevent-kernel-panic-and-reboot-on-shutdown.patch
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard-4.14/0002-rtc-omap-Prevent-kernel-panic-and-reboot-on-shutdown.patch
@@ -1,0 +1,46 @@
+From 347ec78ce2381642a6dc662e8865c6179eed5544 Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Fri, 6 Mar 2020 19:08:29 +0100
+Subject: [PATCH] rtc-omap: Prevent kernel panic and reboot on shutdown
+
+On some beaglebone green wireless boards the rtc
+doesn't work correctly and this causes the PMIC
+to not cut the power at shutdown. This causes
+a kernel panic and reboot.
+
+If this module would be disabled, then the
+system would still stay on but there would
+be no kernel panic.
+
+Keep the system idle in this case.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ drivers/rtc/rtc-omap.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/rtc/rtc-omap.c b/drivers/rtc/rtc-omap.c
+index 2d9f7e38c7ca..025f51a678ac 100644
+--- a/drivers/rtc/rtc-omap.c
++++ b/drivers/rtc/rtc-omap.c
+@@ -529,7 +529,15 @@ static void omap_rtc_power_off(void)
+ 	 */
+ 	mdelay(2500);
+ 
+-	pr_err("rtc_power_off failed, bailing out.\n");
++	pr_err("rtc_power_off failed, please power off the device manually\.n");
++
++	/* The RTC should trigger the PMIC to cut the power, but if the
++	 * RTC is not working properly there's not much that we
++	 * can do but put the system in idle mode. This way we prevent
++	 * a kernel panic that would reboot the system.
++	 */
++	while (1)
++		cpu_relax();
+ }
+ 
+ static void omap_rtc_cleanup_pm_power_off(struct omap_rtc *rtc)
+-- 
+2.17.1
+

--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
@@ -14,6 +14,7 @@ SRC_URI_append_beaglebone = " \
 
 SRC_URI_append_beaglebone-green-wifi = " \
         file://0001-Use-kernel-4.9-BBGW-dts-version.patch \
+        file://0002-rtc-omap-Prevent-kernel-panic-and-reboot-on-shutdown.patch \
 "
 
 SRC_URI_append_beagleboard-xm = " \


### PR DESCRIPTION
 - Fix reboot due to kernel panic on some boards on which the rtc doesn't trigger the pmic to power off the system. This kernel panic occurs also with the latest bb image debian 9.9 2019-08-03 from beagleboard.org
 - Update flashing instructions