### PR TITLE
u-boot: Enable autoboot stop for bbgw dev images

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot_2018.11.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot_2018.11.bbappend
@@ -35,4 +35,9 @@ do_deploy_append() {
     install ${WORKDIR}/uEnv.txt_internal ${DEPLOYDIR}
 }
 
+# Let's be able to debug u-boot
+# on development images, for cases
+# where we need to debug it
+OS_DEV_UBOOT_DELAY_beaglebone-green-wifi = "${@bb.utils.contains('DISTRO_FEATURES', 'development-image', '1', '', d)}"
+
 UBOOT_MACHINE = "am335x_boneblack_config"


### PR DESCRIPTION
We may sometimes need to debug or
work on u-boot in development images.

Let's enable autoboot stop on development
images.

Changelog-entry: u-boot: Enable autoboot stop for bbgw dev images
Signed-off-by: Alexandru Costache <alexandru@balena.io>