### PR TITLE
u-boot: Use meta-balena fs uuids for beaglebones

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot/0001-am335x_evm-uEnv.txt-bootz-n-fixes.patch
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot/0001-am335x_evm-uEnv.txt-bootz-n-fixes.patch
@@ -1080,7 +1080,7 @@ index 785fc15345..110c426058 100644
 +		"${cape_disable} " \
 +		"${cape_enable} " \
 +		"${cape_uboot} " \
-+		"root=PARTUUID=${uuid} ro " \
++		"${resin_kernel_root} ro " \
 +		"rootfstype=${mmcrootfstype} " \
 +		"${uboot_detected_capes} " \
 +		"${cmdline}\0" \
@@ -1102,7 +1102,7 @@ index 785fc15345..110c426058 100644
 +		"${cape_disable} " \
 +		"${cape_enable} " \
 +		"${cape_uboot} " \
-+		"root=UUID=${uuid} ro " \
++		"${resin_kernel_root} ro " \
 +		"rootfstype=${mmcrootfstype} " \
 +		"${uboot_detected_capes} " \
 +		"${cmdline}\0" \


### PR DESCRIPTION
This board was using part uuids for booting. Switch to the meta-balena provided fs uuid for root.

Changelog-entry: u-boot: Use meta-balena fs uuids for beaglebones
Signed-off-by: Alexandru Costache <alexandru@balena.io>