### PR TITLE
linux-beagleboard: Revert "cpsw: fix min eth packet size"

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard-5.4/0001-Revert-net-ethernet-ti-cpsw-fix-min-eth-packet-size.patch
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard-5.4/0001-Revert-net-ethernet-ti-cpsw-fix-min-eth-packet-size.patch
@@ -1,0 +1,46 @@
+From 252ec8eaa636afd4e6978006f8b2ce3c295e178e Mon Sep 17 00:00:00 2001
+From: Zahari Petkov <zahari@balena.io>
+Date: Tue, 15 Dec 2020 23:01:56 +0200
+Subject: [PATCH] Revert "net: ethernet: ti: cpsw: fix min eth packet size"
+
+This reverts commit 9421c90150470512bd5d0fc49eaa108a0b195358
+from our kernel tree.
+
+The above commit increased the min tx packet size from 60 to
+64 bytes. While this fixes VLAN packets forwarding it breaks
+communication with some industrial PLC devices, which drop
+those packets as incorrect because of the extra padding added.
+
+Commit d0ff769214e9705573554921c6a8fe491e01fa30 ("HACK: net:
+ethernet: ti: cpsw: allow to configure min tx packet size")
+introduces boot time configurability with a module boot
+parameter "tx_packet_min", which can be adjusted according
+to the use-case, however we considered that 60 bytes is a
+better default value.
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Zahari Petkov <zahari@balena.io>
+---
+ drivers/net/ethernet/ti/cpsw_priv.h | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/ti/cpsw_priv.h b/drivers/net/ethernet/ti/cpsw_priv.h
+index 77513d42b506..8535c490bbac 100644
+--- a/drivers/net/ethernet/ti/cpsw_priv.h
++++ b/drivers/net/ethernet/ti/cpsw_priv.h
+@@ -86,10 +86,8 @@ do {								\
+ 
+ #define CPSW_POLL_WEIGHT	64
+ #define CPSW_RX_VLAN_ENCAP_HDR_SIZE		4
+-#define CPSW_MIN_PACKET_SIZE	(VLAN_ETH_ZLEN)
+-#define CPSW_MAX_PACKET_SIZE	(VLAN_ETH_FRAME_LEN +\
+-				 ETH_FCS_LEN +\
+-				 CPSW_RX_VLAN_ENCAP_HDR_SIZE)
++#define CPSW_MIN_PACKET_SIZE	60
++#define CPSW_MAX_PACKET_SIZE	(1500 + 14 + 4 + 4)
+ 
+ #define RX_PRIORITY_MAPPING	0x76543210
+ #define TX_PRIORITY_MAPPING	0x33221100
+-- 
+2.29.2
+

--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
@@ -12,6 +12,7 @@ KERNEL_DEVICETREE_beaglebone += " \
 
 SRC_URI_append_beaglebone = " \
 	file://rtc-omap-Prevent-kernel-panic-and-reboot-on-shutdown.patch \
+        file://0001-Revert-net-ethernet-ti-cpsw-fix-min-eth-packet-size.patch \
 "
 
 SRC_URI_append_beagleboard-xm = " \


### PR DESCRIPTION
This reverts commit 9421c90150470512bd5d0fc49eaa108a0b195358 ("net: ethernet: ti: cpsw: fix min eth packet size") from our kernel tree.

The above commit increased the min tx packet size from 60 to 64 bytes. While this fixes VLAN packets forwarding it breaks communication with some industrial PLC devices, which drop those packets as incorrect because of the extra padding added.

Commit d0ff769214e9705573554921c6a8fe491e01fa30 ("HACK: net: ethernet: ti: cpsw: allow to configure min tx packet size") introduces boot time configurability with a module boot parameter "tx_packet_min", which can be adjusted according to the use-case, however we considered that 60 bytes is a better default value.

Changelog-entry: linux-beagleboard: Revert "cpsw: fix min eth packet size"
Signed-off-by: Zahari Petkov <zahari@balena.io>