### PR TITLE
balena-beaglebone: Rename resin image types to balena

### DIFF
--- a/beagleboard-xm.coffee
+++ b/beagleboard-xm.coffee
@@ -19,10 +19,10 @@ module.exports =
 
 	yocto:
 		machine: 'beagleboard-xm'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-beagleboard-xm.resinos-img'
+		deployArtifact: 'balena-image-beagleboard-xm.balenaos-img'
 		compressed: true
 
 	options: [ networkOptions.group ]

--- a/beaglebone-green-gateway.coffee
+++ b/beaglebone-green-gateway.coffee
@@ -38,10 +38,10 @@ module.exports =
 
 	yocto:
 		machine: 'beaglebone-green-gateway'
-		image: 'resin-image-flasher'
-		fstype: 'resinos-img'
+		image: 'balena-image-flasher'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-flasher-beaglebone-green-gateway.resinos-img'
+		deployArtifact: 'balena-image-flasher-beaglebone-green-gateway.balenaos-img'
 		compressed: true
 
 	options: [ networkOptions.group ]

--- a/beaglebone-green-wifi.coffee
+++ b/beaglebone-green-wifi.coffee
@@ -38,10 +38,10 @@ module.exports =
 
 	yocto:
 		machine: 'beaglebone-green-wifi'
-		image: 'resin-image-flasher'
-		fstype: 'resinos-img'
+		image: 'balena-image-flasher'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-flasher-beaglebone-green-wifi.resinos-img'
+		deployArtifact: 'balena-image-flasher-beaglebone-green-wifi.balenaos-img'
 		compressed: true
 
 	options: [ networkOptions.group ]

--- a/beaglebone-green.coffee
+++ b/beaglebone-green.coffee
@@ -36,10 +36,10 @@ module.exports =
 
 	yocto:
 		machine: 'beaglebone-green'
-		image: 'resin-image-flasher'
-		fstype: 'resinos-img'
+		image: 'balena-image-flasher'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-flasher-beaglebone-green.resinos-img'
+		deployArtifact: 'balena-image-flasher-beaglebone-green.balenaos-img'
 		compressed: true
 
 	options: [ networkOptions.group ]

--- a/beaglebone-pocket.coffee
+++ b/beaglebone-pocket.coffee
@@ -25,10 +25,10 @@ module.exports =
 
 	yocto:
 		machine: 'beaglebone-pocket'
-		image: 'resin-image'
-		fstype: 'resinos-img'
+		image: 'balena-image'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-beaglebone-pocket.resinos-img'
+		deployArtifact: 'balena-image-beaglebone-pocket.balenaos-img'
 		compressed: true
 
 	options: [ networkOptions.group ]

--- a/beaglebone.coffee
+++ b/beaglebone.coffee
@@ -37,10 +37,10 @@ module.exports =
 
 	yocto:
 		machine: 'beaglebone'
-		image: 'resin-image-flasher'
-		fstype: 'resinos-img'
+		image: 'balena-image-flasher'
+		fstype: 'balenaos-img'
 		version: 'yocto-dunfell'
-		deployArtifact: 'resin-image-flasher-beaglebone.resinos-img'
+		deployArtifact: 'balena-image-flasher-beaglebone.balenaos-img'
 		compressed: true
 
 	options: [ networkOptions.group ]

--- a/layers/meta-balena-beaglebone/conf/samples/local.conf.sample
+++ b/layers/meta-balena-beaglebone/conf/samples/local.conf.sample
@@ -24,7 +24,7 @@ BALENA_STORAGE_beaglebone-green-gateway = "overlay2"
 #SUPERVISOR_TAG ?= "master"
 
 # Compress final raw image
-#RESIN_RAW_IMG_COMPRESSION ?= "xz"
+#BALENA_RAW_IMG_COMPRESSION ?= "xz"
 
 # Parallelism Options
 BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"

--- a/layers/meta-balena-beaglebone/recipes-bsp/beagle-serial/beagle-serial.bb
+++ b/layers/meta-balena-beaglebone/recipes-bsp/beagle-serial/beagle-serial.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Udev rule to create ttyO* -> ttyS* symlinks on Beagle* boards"
 
 LICENSE="Apache-2.0"
-LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 DESCRIPTION = "Udev rule to create ttyO* -> ttyS* symlinks on Beagle* boards"
 

--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot/0003-resin-specific-env-integration-kconfig_REWORKED.patch
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot/0003-resin-specific-env-integration-kconfig_REWORKED.patch
@@ -30,7 +30,7 @@ index 86b639d..b18244f 100644
  #else
  const uchar default_environment[] = {
  #endif
-+    RESIN_ENV
++    BALENA_ENV
  #ifndef CONFIG_USE_DEFAULT_ENV_FILE
  #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
  	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"

--- a/layers/meta-balena-beaglebone/recipes-connectivity/bb-wl18xx-bluetooth/bb-wl18xx-bluetooth.bb
+++ b/layers/meta-balena-beaglebone/recipes-connectivity/bb-wl18xx-bluetooth/bb-wl18xx-bluetooth.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "BB WL18xx Bluetooth"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = " \
 	file://bb-wl18xx-bluetooth \

--- a/layers/meta-balena-beaglebone/recipes-connectivity/bb-wl18xx-bluetooth/bb-wl18xx-btwl.bb
+++ b/layers/meta-balena-beaglebone/recipes-connectivity/bb-wl18xx-bluetooth/bb-wl18xx-btwl.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "BB WL18xx Bluetooth"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = " \
 	file://bb-wl18xx-btwl \

--- a/layers/meta-balena-beaglebone/recipes-connectivity/bb-wl18xx-wlan0/bb-wl18xx-wlan0.bb
+++ b/layers/meta-balena-beaglebone/recipes-connectivity/bb-wl18xx-wlan0/bb-wl18xx-wlan0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Set wifi MAC address"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = " \
 	file://bb-wl18xx-wlan0 \

--- a/layers/meta-balena-beaglebone/recipes-core/fix-mmc-bbb/fix-mmc-bbb.bb
+++ b/layers/meta-balena-beaglebone/recipes-core/fix-mmc-bbb/fix-mmc-bbb.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Apply memory pressure fix"
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+LIC_FILES_CHKSUM = "file://${BALENA_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRC_URI = "file://fix-mmc-bbb.conf"
 

--- a/layers/meta-balena-beaglebone/recipes-core/images/balena-image-flasher.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/images/balena-image-flasher.bbappend
@@ -1,0 +1,4 @@
+include balena-image.inc
+
+BALENA_BOOT_PARTITION_FILES_append_beaglebone = " uEnv.txt_internal:"
+IMAGE_INSTALL_append_beaglebone = " bb-org-overlays"

--- a/layers/meta-balena-beaglebone/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/images/balena-image.bbappend
@@ -1,4 +1,4 @@
-include resin-image.inc
+include balena-image.inc
 
 IMAGE_INSTALL_append_beaglebone = " bb-org-overlays fix-mmc-bbb bb-wl18xx-bluetooth bb-wl18xx-wlan0"
 IMAGE_INSTALL_append_beaglebone-pocket = " boot-scripts"

--- a/layers/meta-balena-beaglebone/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-beaglebone/recipes-core/images/balena-image.inc
@@ -1,14 +1,14 @@
-IMAGE_FSTYPES_append_beaglebone = " resinos-img resinos-img.bmap"
-IMAGE_FSTYPES_append_beaglebone-pocket = " resinos-img"
-IMAGE_FSTYPES_append_beagleboard-xm = " resinos-img"
+IMAGE_FSTYPES_append_beaglebone = " balenaos-img balenaos-img.bmap"
+IMAGE_FSTYPES_append_beaglebone-pocket = " balenaos-img"
+IMAGE_FSTYPES_append_beagleboard-xm = " balenaos-img"
 
-# Customize resinos-img
-RESIN_BOOT_PARTITION_FILES_beaglebone = " \
+# Customize balenaos-img
+BALENA_BOOT_PARTITION_FILES_beaglebone = " \
     MLO: \
     u-boot.img: \
     "
 
-RESIN_BOOT_PARTITION_FILES_beagleboard-xm = " \
+BALENA_BOOT_PARTITION_FILES_beagleboard-xm = " \
     MLO: \
     u-boot.img: \
 "
@@ -18,7 +18,7 @@ IMAGE_INSTALL_append = " kernel-image-initramfs kernel-devicetree wlconf"
 
 IMAGE_INSTALL_append = " beagle-serial"
 
-RESIN_BOOT_PARTITION_FILES_append_beaglebone-pocket = " uEnv.txt_internal:"
+BALENA_BOOT_PARTITION_FILES_append_beaglebone-pocket = " uEnv.txt_internal:"
 
 # Fixes error: packages already installed
 # by kernel-image-initramfs

--- a/layers/meta-balena-beaglebone/recipes-core/images/resin-image-flasher.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/images/resin-image-flasher.bbappend
@@ -1,4 +1,0 @@
-include resin-image.inc
-
-RESIN_BOOT_PARTITION_FILES_append_beaglebone = " uEnv.txt_internal:"
-IMAGE_INSTALL_append_beaglebone = " bb-org-overlays"

--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_%.bbappend
@@ -1,6 +1,6 @@
 # disable modules compression
-RESIN_CONFIGS_append = " no_modules_compression"
-RESIN_CONFIGS[no_modules_compression]=" \
+BALENA_CONFIGS_append = " no_modules_compression"
+BALENA_CONFIGS[no_modules_compression]=" \
     CONFIG_MODULE_COMPRESS=n \
     CONFIG_MODULE_COMPRESS_XZ=n \
 "
@@ -20,37 +20,37 @@ SRC_URI_append_beagleboard-xm = " \
 	file://0001-card-power-cycle.patch \
 "
 
-RESIN_CONFIGS_append_beagleboard-xm = " omap3_soc \
+BALENA_CONFIGS_append_beagleboard-xm = " omap3_soc \
 	twl4030 \
 "
 
-RESIN_CONFIGS[omap3_soc] = " \
+BALENA_CONFIGS[omap3_soc] = " \
 	CONFIG_ARCH_OMAP3=y \
 	CONFIG_USB_MUSB_OMAP2PLUS=y \
 "
 
-RESIN_CONFIGS[twl4030] = " \
+BALENA_CONFIGS[twl4030] = " \
 	CONFIG_REGULATOR_TWL4030=y \
 	CONFIG_TWL4030_USB=y \
 	CONFIG_GPIO_TWL4030=y \
 "
 
-RESIN_CONFIGS_append = " alt_serial"
-RESIN_CONFIGS[alt_serial] = "\
+BALENA_CONFIGS_append = " alt_serial"
+BALENA_CONFIGS[alt_serial] = "\
 	CONFIG_SERIAL_OMAP=y \
 	CONFIG_SERIAL_OMAP_CONSOLE=y \
 	CONFIG_SERIAL_8250=n \
 "
 
-RESIN_CONFIGS_append = " bt_hciuart"
-RESIN_CONFIGS[bt_hciuart] = " \
+BALENA_CONFIGS_append = " bt_hciuart"
+BALENA_CONFIGS[bt_hciuart] = " \
 	CONFIG_BT_HCIUART=m \
 	CONFIG_BT_HCIUART_SERDEV=y \
 	CONFIG_BT_HCIUART_H4=y \
 	CONFIG_BT_HCIUART_LL=y \
 "
 
-RESIN_CONFIGS_append = " hm3301"
-RESIN_CONFIGS[hm3301] = " \
+BALENA_CONFIGS_append = " hm3301"
+BALENA_CONFIGS[hm3301] = " \
         CONFIG_HM3301=m \
 "


### PR DESCRIPTION
Rename resin image types to balena and replace RESIN_ env vars

Changelog-entry: Rename resin image types to balena
Signed-off-by: Kyle Harding <kyle@balena.io>