### PR TITLE
balena-beaglebone: fix for beaglebone green wireless gpio

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_5.4.bb
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_5.4.bb
@@ -12,7 +12,7 @@ DEPENDS += "lzop-native"
 # Look in the generic major.minor directory for files
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-5.4:"
 
-KERNEL_DEVICETREE_beaglebone = "am335x-bone.dtb am335x-boneblack.dtb am335x-boneblack-wireless.dtb am335x-boneblue.dtb am335x-bonegreen.dtb am335x-bonegreen-wireless.dtb"
+KERNEL_DEVICETREE_beaglebone = "am335x-bone.dtb am335x-boneblack.dtb am335x-boneblack-wireless.dtb am335x-boneblue.dtb am335x-bonegreen.dtb am335x-bonegreen-wireless.dtb am335x-bonegreen-wireless-uboot-univ.dtb"
 
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 


### PR DESCRIPTION
added am335x-bonegreen-wireless-uboot-univ overlay to linux-beagleboard to fix issue with beaglebone green wireless gpio not being registered.