### PR TITLE
linux-beagleboard: Add am335x-bonegreen-wireless-uboot-univ to rootfs

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_5.4.bb
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_5.4.bb
@@ -12,7 +12,7 @@ DEPENDS += "lzop-native"
 # Look in the generic major.minor directory for files
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-5.4:"
 
-KERNEL_DEVICETREE_beaglebone = "am335x-bone.dtb am335x-boneblack.dtb am335x-boneblack-wireless.dtb am335x-boneblue.dtb am335x-bonegreen.dtb am335x-bonegreen-wireless.dtb"
+KERNEL_DEVICETREE_beaglebone = "am335x-bone.dtb am335x-boneblack.dtb am335x-boneblack-wireless.dtb am335x-boneblue.dtb am335x-bonegreen.dtb am335x-bonegreen-wireless.dtb am335x-bonegreen-wireless-uboot-univ.dtb"
 
 KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
 


### PR DESCRIPTION
Include this overlay so that users of BeagleBone Green Wireless can load
it and use the gpios.

Changelog-entry: Add am335x-bonegreen-wireless-uboot-univ to rootfs for people using gpios on BeagleBone Green Wireless