### PR TITLE
Update meta-balena to 2.88.17

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_5.4.bb
+++ b/layers/meta-balena-beaglebone/recipes-kernel/linux/linux-beagleboard_5.4.bb
@@ -37,7 +37,7 @@ KERNEL_CONFIG_DIR = "${S}/ti_config_fragments"
 MULTI_CONFIG_BASE_SUFFIX = ""
 
 KERNEL_GIT_URI = "git://github.com/beagleboard/linux.git"
-KERNEL_GIT_PROTOCOL = "git"
+KERNEL_GIT_PROTOCOL = "https"
 SRC_URI += " \
     ${KERNEL_GIT_URI};protocol=${KERNEL_GIT_PROTOCOL};tag=${TAG};nobranch=1 \
     file://0001-Revert-random-fix-crng_ready-test.patch \


### PR DESCRIPTION
Update meta-balena from 2.85.16 to 2.88.17

Changelog-entry: Update meta-balena from v2.85.16 to v2.88.17
Signed-off-by: Florin Sarbu <florin@balena.io>