### PR TITLE
recipes-core/systemd: Move audit socket removal to meta-balena

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-core/systemd/systemd_%.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/systemd/systemd_%.bbappend
@@ -1,5 +1,0 @@
-do_install_append() {
-    # disable audit messages
-    rm ${D}/lib/systemd/system/sockets.target.wants/systemd-journald-audit.socket
-    rm ${D}/lib/systemd/system/systemd-journald-audit.socket
-}


### PR DESCRIPTION
Removal of audit sockets to disable audit messages should
be done in meta-balena.

Changelog-entry: recipes-core/systemd: Move audit socket removal to meta-balena
Signed-off-by: Alexandru Costache <alexandru@balena.io>