### PR TITLE
beagleboard-xm: Discontinue device

### DIFF
--- a/beagleboard-xm.coffee
+++ b/beagleboard-xm.coffee
@@ -6,7 +6,7 @@ module.exports =
 	slug: 'beagleboard-xm'
 	name: 'BeagleBoard-XM'
 	arch: 'armv7hf'
-	state: 'released'
+	state: 'discontinued'
 
 	instructions: commonImg.instructions
 


### PR DESCRIPTION
As per the internal thread https://balena.zulipchat.com/#narrow/stream/360838-balena-io.2Fos.2Fdevices/topic/Beagleboard.20XM.20discontinuation/near/381916302

The platform used for this device ype has been deprecated and will no longer be supported in upstream. See https://git.yoctoproject.org/meta-ti/commit/?id=209da2791f911235faaf4104ebf289b0e11d975b

Changelog-entry: beagleboard-xm: Discontinue device