### PR TITLE
Install video decoder's firmware on the BBAI64.

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-core/images/balena-image-flasher.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/images/balena-image-flasher.bbappend
@@ -2,4 +2,4 @@ include balena-image.inc
 
 BALENA_BOOT_PARTITION_FILES:append:beaglebone = " uEnv.txt_internal:"
 IMAGE_INSTALL:append:beaglebone = " bb-org-overlays"
-IMAGE_INSTALL:append:beaglebone-ai64 = " mmc-utils"
+IMAGE_INSTALL:append:beaglebone-ai64 = " mmc-utils vxd-dec-fw"

--- a/layers/meta-balena-beaglebone/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/images/balena-image-initramfs.bbappend
@@ -2,3 +2,4 @@
 # of zImage, so we need a bigger rootfs image size in order to account for this
 # on the initramfs.
 IMAGE_ROOTFS_MAXSIZE:beaglebone-ai64 = "65536"
+PACKAGE_INSTALL:append:beaglebone-ai64 = " cadence-mhdp-fw"

--- a/layers/meta-balena-beaglebone/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/images/balena-image.bbappend
@@ -1,7 +1,7 @@
 include balena-image.inc
 
 # This might be probably removed or reduced once the kernel gets compressed.
-IMAGE_ROOTFS_SIZE:beaglebone-ai64 = "458752"
+IMAGE_ROOTFS_SIZE:beaglebone-ai64 = "733184"
 
 IMAGE_INSTALL:append:beaglebone = " bb-org-overlays fix-mmc-bbb bb-wl18xx-bluetooth bb-wl18xx-wlan0"
 IMAGE_INSTALL:append:beaglebone-ai64 = " mmc-utils vxd-dec-fw"

--- a/layers/meta-balena-beaglebone/recipes-core/images/balena-image.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/images/balena-image.bbappend
@@ -4,5 +4,5 @@ include balena-image.inc
 IMAGE_ROOTFS_SIZE:beaglebone-ai64 = "458752"
 
 IMAGE_INSTALL:append:beaglebone = " bb-org-overlays fix-mmc-bbb bb-wl18xx-bluetooth bb-wl18xx-wlan0"
-IMAGE_INSTALL:append:beaglebone-ai64 = " mmc-utils"
+IMAGE_INSTALL:append:beaglebone-ai64 = " mmc-utils vxd-dec-fw"
 IMAGE_INSTALL:append:beaglebone-pocket = " boot-scripts"


### PR DESCRIPTION
The BeagleBone AI-64 requires the vxd-dec-fw package in order to bring in the video decoder firmware. This avoids:

```
img_dec 4300000.video-decoder: Error!! fw binary is not present
```

dmesg message.

Changelog-entry: Add video decodr firmware for the BeagleBone AI64.
Change-type: patch
Signed-By: Lisandro Pérez Meyer <lperezmeyer@ics.com>