### PR TITLE
BBAI64: Add support for the correct resin partitions.

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0001-Integrate-with-Balena-u-boot-environment.patch
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0001-Integrate-with-Balena-u-boot-environment.patch
@@ -12,10 +12,10 @@ Signed-off-by: Lisandro Pérez Meyer <lperezmeyer@ics.com>
  include/config_distro_bootcmd.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
-index 9d2a225e7e..0d2ae1a889 100644
---- a/include/config_distro_bootcmd.h
-+++ b/include/config_distro_bootcmd.h
+Index: git/include/config_distro_bootcmd.h
+===================================================================
+--- git.orig/include/config_distro_bootcmd.h
++++ git/include/config_distro_bootcmd.h
 @@ -515,7 +515,7 @@
  		"\0"                                                      \
  	\
@@ -25,6 +25,29 @@ index 9d2a225e7e..0d2ae1a889 100644
  		"env exists devplist || setenv devplist 1; "              \
  		"for distro_bootpart in ${devplist}; do "                 \
  			"if fstype ${devtype} "                           \
--- 
-2.25.1
-
+Index: git/configs/j721e_beagleboneai64_a72.config
+===================================================================
+--- git.orig/configs/j721e_beagleboneai64_a72.config
++++ git/configs/j721e_beagleboneai64_a72.config
+@@ -3,7 +3,7 @@
+ CONFIG_DEFAULT_DEVICE_TREE="k3-j721e-beagleboneai64"
+ CONFIG_SPL_OF_LIST="k3-j721e-beagleboneai64 k3-j721e-sk"
+ CONFIG_OF_LIST="k3-j721e-beagleboneai64 k3-j721e-sk"
+-CONFIG_BOOTCOMMAND="run findfdt; run envboot; run distro_bootcmd"
++CONFIG_BOOTCOMMAND="run findfdt; setenv resin_kernel_load_addr ${loadaddr}; run resin_set_kernel_root; setenv mmcdev ${resin_dev_index}; setenv bootpart ${resin_dev_index}:${resin_root_part}; run envboot; run distro_bootcmd"
+ CONFIG_EXT4_WRITE=y
+ CONFIG_LZO=y
+ CONFIG_AUTOBOOT_KEYED=y
+Index: git/configs/j721e_evm_a72_defconfig
+===================================================================
+--- git.orig/configs/j721e_evm_a72_defconfig
++++ git/configs/j721e_evm_a72_defconfig
+@@ -30,7 +30,7 @@ CONFIG_SPL_LOAD_FIT=y
+ CONFIG_SPL_LOAD_FIT_ADDRESS=0x81000000
+ CONFIG_OF_BOARD_SETUP=y
+ CONFIG_DISTRO_DEFAULTS=y
+-CONFIG_BOOTCOMMAND="run envboot; run distro_bootcmd;"
++CONFIG_BOOTCOMMAND="run findfdt; setenv resin_kernel_load_addr ${loadaddr}; run resin_set_kernel_root; setenv mmcdev ${resin_dev_index}; setenv bootpart ${resin_dev_index}:${resin_root_part}; run envboot; run distro_bootcmd"
+ CONFIG_LOGLEVEL=7
+ CONFIG_SPL_MAX_SIZE=0xc0000
+ CONFIG_SPL_HAS_BSS_LINKER_SECTION=y

--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0002-env_default.h-Add-support-for-OS_KERNEL_CMDLINE.patch
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging/0002-env_default.h-Add-support-for-OS_KERNEL_CMDLINE.patch
@@ -1,0 +1,77 @@
+Index: git/include/environment/ti/mmc.h
+===================================================================
+--- git.orig/include/environment/ti/mmc.h
++++ git/include/environment/ti/mmc.h
+@@ -14,8 +14,8 @@
+ 	"finduuid=part uuid ${boot} ${bootpart} uuid\0" \
+ 	"args_mmc=run finduuid;setenv bootargs console=${console} " \
+ 		"${optargs} " \
+-		"root=PARTUUID=${uuid} rw " \
+-		"rootfstype=${mmcrootfstype}\0" \
++		"${resin_kernel_root}" \
++		"${os_cmdline}"
+ 	"loadbootscript=load mmc ${mmcdev} ${loadaddr} boot.scr\0" \
+ 	"bootscript=echo Running bootscript from mmc${mmcdev} ...; " \
+ 		"source ${loadaddr}\0" \
+@@ -23,8 +23,8 @@
+ 	"importbootenv=echo Importing environment from mmc${mmcdev} ...; " \
+ 		"env import -t ${loadaddr} ${filesize}\0" \
+ 	"loadbootenv=fatload mmc ${mmcdev} ${loadaddr} ${bootenvfile}\0" \
+-	"loadimage=load ${devtype} ${bootpart} ${loadaddr} ${bootdir}/${bootfile}\0" \
+-	"loadfdt=load ${devtype} ${bootpart} ${fdtaddr} ${bootdir}/${fdtfile}\0" \
++	"loadimage=load ${devtype} ${resin_dev_index}:${resin_root_part} ${loadaddr} ${bootdir}/${bootfile}\0" \
++	"loadfdt=load ${devtype} ${resin_dev_index}:${resin_root_part} ${fdtaddr} ${bootdir}/${fdtfile}\0" \
+ 	"envboot=mmc dev ${mmcdev}; " \
+ 		"if mmc rescan; then " \
+ 			"echo SD/MMC found on device ${mmcdev};" \
+Index: git/include/environment/ti/mmc.env
+===================================================================
+--- git.orig/include/environment/ti/mmc.env
++++ git/include/environment/ti/mmc.env
+@@ -3,8 +3,7 @@ mmcrootfstype=ext4 rootwait
+ finduuid=part uuid ${boot} ${bootpart} uuid
+ args_mmc=run finduuid;setenv bootargs console=${console}
+ 	${optargs}
+-	root=PARTUUID=${uuid} rw
+-	rootfstype=${mmcrootfstype}
++	${resin_kernel_root}
+ loadbootscript=load mmc ${mmcdev} ${loadaddr} boot.scr
+ bootscript=echo Running bootscript from mmc${mmcdev} ...;
+ 	source ${loadaddr}
+@@ -12,9 +11,9 @@ bootenvfile=uEnv.txt
+ importbootenv=echo Importing environment from mmc${mmcdev} ...;
+ 	env import -t ${loadaddr} ${filesize}
+ loadbootenv=fatload mmc ${mmcdev} ${loadaddr} ${bootenvfile}
+-loadimage=load ${devtype} ${bootpart} ${loadaddr} ${bootdir}/${bootfile}
+-loadfdt=load ${devtype} ${bootpart} ${fdtaddr} ${bootdir}/dtb/${fdtfile}
+-get_fdt_mmc=load mmc ${bootpart} ${fdtaddr} ${bootdir}/dtb/${name_fdt}
++loadimage=load ${devtype} ${resin_dev_index}:${resin_root_part} ${loadaddr} ${bootdir}/${bootfile}
++loadfdt=load ${devtype} ${resin_dev_index}:${resin_root_part} ${fdtaddr} ${bootdir}/dtb/${fdtfile}
++get_fdt_mmc=load mmc ${resin_dev_index}:${resin_root_part} ${fdtaddr} ${bootdir}/dtb/${name_fdt}
+ envboot=mmc dev ${mmcdev};
+ 	if mmc rescan; then
+ 		echo SD/MMC found on device ${mmcdev};
+@@ -66,11 +65,11 @@ get_overlay_mmc=
+ 	fdt resize 0x100000;
+ 	for overlay in $name_overlays;
+ 	do;
+-	load mmc ${bootpart} ${dtboaddr} ${bootdir}/dtb/ti/${overlay} &&
++	load mmc ${resin_dev_index}:${resin_root_part} ${dtboaddr} ${bootdir}/dtb/ti/${overlay} &&
+ 	fdt apply ${dtboaddr};
+ 	done;
+-get_kern_mmc=load mmc ${bootpart} ${loadaddr}
++get_kern_mmc=load mmc ${resin_dev_index}:${resin_root_part} ${loadaddr}
+ 	${bootdir}/${name_kern}
+-get_fit_mmc=load mmc ${bootpart} ${addr_fit}
++get_fit_mmc=load mmc ${resin_dev_index}:${resin_root_part} ${addr_fit}
+ 	${bootdir}/${name_fit}
+ partitions=name=rootfs,start=0,size=-,uuid=${uuid_gpt_rootfs}
+Index: git/board/ti/j721e/j721e.env
+===================================================================
+--- git.orig/board/ti/j721e/j721e.env
++++ git/board/ti/j721e/j721e.env
+@@ -1,3 +1,4 @@
++#include <env_resin.h>
+ #include <environment/ti/ti_armv7_common.env>
+ #include <environment/ti/mmc.env>
+ #include <environment/ti/ufs.env>

--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -5,6 +5,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = " \
     file://0001-Integrate-with-Balena-u-boot-environment.patch \
+    file://0002-env_default.h-Add-support-for-OS_KERNEL_CMDLINE.patch \
 "
 
 SRC_URI:append:beaglebone-ai64 = " \


### PR DESCRIPTION
It is worth to note that, using the current meta-ti version in this
repository,u-boot-ti-staging seems to be using j721e_evm_a72_defconfig
instead of the j721e_beagleboneai64_a72.config file.
    
This works, but an update of meta-ti and the subsequent fixes should be
considered.
    
Changed-by: Lisandro Pérez Meyer <lpmeyer@ics.com>
Changelog-Entry: bbai64: use the correct resin partitions when booting
