### PR TITLE
README.md: Clean up the contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,28 +78,12 @@ Changelog-entry: User facing description of the issue
 Signed-off-by: Joe Developer <joe.developer@example.com>
 ```
 
-The header of each commit must not exceed 72 characters in length and must be in 1 line only.
-
 The header and the subject of each commit must be separated by an empty line.
-
-The subject of each commit must not exceed 72 characters per line and can be wrapped to several lines.
 
 The subject and the footer of each commit must be separated by an empty line.
 
 Every pull request must contain at least one commit annotated with the `Changelog-entry` footer. The messages contained in these footers will be used to automatically fill the changelog on every new version.
 
-Also, every update to `meta-balena` should be separated into its own commit, if the body of that commit contains the following line `Updated meta-balena from X to Y` the generated changelog will include a button to show all the updates in `meta-balena` from the version after `X` to `Y`.
-
-An example of a valid commit updating `meta-balena` is:
-
-```
-layers/meta-balena: Update to v2.24.0
-
-Update meta-balena from 2.19.0 to 2.24.0
-
-Changelog-entry: Update meta-balena from v2.19.0 to v2.24.0
-```
-
-Make sure you mention the issue addressed by a PR. See:
+If your PR fixes an open issue, make sure you mention the issue addressed by the PR. See:
 * https://help.github.com/articles/autolinked-references-and-urls/#issues-and-pull-requests
 * https://help.github.com/articles/closing-issues-via-commit-messages/#closing-an-issue-in-a-different-repository


### PR DESCRIPTION
Manual updates of meta-balena are no longer neeeded so we remove that info. Also, clean up the restrictions on the commit message length since that's not used anymore either.

Changelog-entry: Clean up the contributing section from README.md