### PR TITLE
u-boot-bb-org: remove unneeded config stanza

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot-bb.org_%.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-bsp/u-boot/u-boot-bb.org_%.bbappend
@@ -1,6 +1,5 @@
 FILESEXTRAPATHS:append := ":${THISDIR}/${PN}"
 
-UBOOT_KCONFIG_SUPPORT = "1"
 inherit resin-u-boot
 
 SRC_URI += " \


### PR DESCRIPTION
UBOOT_KCONFIG_SUPPORT is already enabled when inheriting resin-u-boot, as discussed in
https://github.com/balena-os/balena-beaglebone/pull/662#discussion_r1565590564

Changelog-Entry: u-boot-bb.org: remove uneeded config stanza