### PR TITLE
packagegroup-balena-connectivity: Don't install ath10k firmware

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-core/packagegroups/packagegroup-balena-connectivity.bbappend
@@ -1,1 +1,2 @@
 CONNECTIVITY_FIRMWARES:append = " linux-firmware-wl18xx"
+CONNECTIVITY_FIRMWARES:remove = " linux-firmware-ath10k"


### PR DESCRIPTION
These devices don't need this firmware which will now be brought in by meta-balena PR 3608 by default.

Changelog-entry: packagegroup-balena-connectivity: Don't install ath10k firmware