### PR TITLE
recipes-connectivity/wlconf: switch to using github repository

### DIFF
--- a/layers/meta-balena-beaglebone/recipes-connectivity/wlconf/wlconf_8.7.3.bbappend
+++ b/layers/meta-balena-beaglebone/recipes-connectivity/wlconf/wlconf_8.7.3.bbappend
@@ -1,4 +1,4 @@
-SRC_URI:aarch64 = "git://git.beagleboard.org/beagleboard/18xx-ti-utils.git;protocol=https;branch=R8.7_SP3-bbb.io"
+SRC_URI:aarch64 = "git://github.com//beagleboard/18xx-ti-utils.git;protocol=https;branch=R8.7_SP3-bbb.io"
 SRCREV:aarch64 = "ba027b093aa013637fcc6271c2d47f3ce99e933e"
 
 do_install:append:aarch64() {


### PR DESCRIPTION
previous repository switch to using Anubis and that is preventing Yocto builds from fetching the sources.

Changelog-entry: recipes-connectivity/wlconf: switch to using github repository

Connects-to: https://github.com/beagleboard/beaglebone-ai-64/issues/45