### PR TITLE
patch: fix meta-ti submodule being ref using http

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	branch = master
 [submodule "layers/meta-ti"]
 	path = layers/meta-ti
-	url = http://git.yoctoproject.org/git/meta-ti
+	url = https://git.yoctoproject.org/git/meta-ti
 	branch = kirkstone
 [submodule "layers/poky"]
 	path = layers/poky


### PR DESCRIPTION
https://balena.fibery.io/Security/Vulnerability_or_Exposure/balena-beaglebone-repo-refers-meta-ti-submodules-over-http-82